### PR TITLE
Switches checkout action to v7 with sparse checkouts.

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -21,7 +21,14 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
+      with:
+        sparse-checkout: |
+          .github
+          misalign
+          tests
+          pyproject.toml
+          README.md
     - name: Install uv and set the Python version
       uses: astral-sh/setup-uv@v8.1.0
       with:


### PR DESCRIPTION
Testing sparse checkouts because expanded example data significantly increases the time for CI to run.